### PR TITLE
Optimize css

### DIFF
--- a/js/tobi.js
+++ b/js/tobi.js
@@ -66,12 +66,17 @@
      * Global constants
      *
      */
-    const tobiContentString = '.tobi .content'
-    const tobiIsOpenString = 'tobi-is-open'
-    const tobiZoomIconString = 'tobi-zoom-icon'
-    const tobiZoomString = 'tobi-zoom'
-    const sliderIsDraggingString = 'slider--is-dragging'
-    const sliderIsDraggableString = 'slider--is-draggable'
+    const tobiContentString = 'tobi-content',
+      tobiIsOpenString = 'tobi-is-open',
+      tobiZoomIconString = 'tobi-zoom-icon',
+      tobiZoomString = 'tobi-zoom',
+      tobiSliderIsDraggingString = 'tobi-slider--is-dragging',
+      tobiSliderIsDraggableString = 'tobi-slider--is-draggable',
+      tobiSlideString = 'tobi-slide',
+      tobiLoaderString = 'tobi-loader',
+      tobiContentSelector = '.' + tobiContentString,
+      tobiZoomIconSelector = '.' + tobiZoomIconString,
+      tobiLoaderSelector = '.' + tobiLoaderString
 
     /**
      * Merge default options with user options
@@ -178,7 +183,7 @@
           container.appendChild(figure)
 
           // Create loading indicator
-          loadingIndicator.className = 'loader'
+          loadingIndicator.className = tobiLoaderString
           loadingIndicator.setAttribute('role', 'progressbar')
           loadingIndicator.setAttribute('aria-label', config.loadingIndicatorLabel)
 
@@ -202,7 +207,7 @@
           }
 
           const figcaption = container.querySelector('figcaption')
-          const loadingIndicator = container.querySelector('.loader')
+          const loadingIndicator = container.querySelector(tobiLoaderSelector)
 
           image.onload = function () {
             container.removeChild(loadingIndicator)
@@ -577,8 +582,8 @@
         groups[groupName].elementsLength--
 
         // Remove zoom icon if necessary
-        if (config.zoom && el.querySelector('.' + tobiZoomIconString)) {
-          const zoomIcon = el.querySelector('.' + tobiZoomIconString)
+        if (config.zoom && el.querySelector(tobiZoomIconSelector)) {
+          const zoomIcon = el.querySelector(tobiZoomIconSelector)
 
           zoomIcon.parentNode.classList.remove(tobiZoomString)
           zoomIcon.parentNode.removeChild(zoomIcon)
@@ -638,7 +643,7 @@
 
       // Create the counter
       counter = document.createElement('div')
-      counter.className = 'counter'
+      counter.className = 'tobi-counter'
       lightbox.appendChild(counter)
 
       // Resize event using requestAnimationFrame
@@ -662,7 +667,7 @@
      */
     const createSlider = function createSlider () {
       groups[newGroup].slider = document.createElement('div')
-      groups[newGroup].slider.className = 'slider'
+      groups[newGroup].slider.className = 'tobi-slider'
       lightbox.appendChild(groups[newGroup].slider)
     }
 
@@ -679,10 +684,10 @@
             const sliderElement = document.createElement('div')
             const sliderElementContent = document.createElement('div')
 
-            sliderElement.className = 'slide'
+            sliderElement.className = tobiSlideString
             sliderElement.style.position = 'absolute'
             sliderElement.style.left = groups[newGroup].x * 100 + '%'
-            sliderElementContent.className = 'content'
+            sliderElementContent.className = tobiContentString
 
             // Create type elements
             supportedElements[index].init(el, sliderElementContent)
@@ -789,7 +794,7 @@
       lastFocus.focus()
 
       // Don't forget to cleanup our current element
-      const container = groups[activeGroup].sliderElements[groups[activeGroup].currentIndex].querySelector(tobiContentString)
+      const container = groups[activeGroup].sliderElements[groups[activeGroup].currentIndex].querySelector(tobiContentSelector)
       const type = container.getAttribute('data-type')
 
       supportedElements[type].onLeave(container)
@@ -815,7 +820,7 @@
         return
       }
 
-      const container = groups[activeGroup].sliderElements[index].querySelector(tobiContentString)
+      const container = groups[activeGroup].sliderElements[index].querySelector(tobiContentSelector)
       const type = container.getAttribute('data-type')
 
       supportedElements[type].onPreload(container)
@@ -832,7 +837,7 @@
         return
       }
 
-      const container = groups[activeGroup].sliderElements[index].querySelector(tobiContentString)
+      const container = groups[activeGroup].sliderElements[index].querySelector(tobiContentSelector)
       const type = container.getAttribute('data-type')
 
       supportedElements[type].onLoad(container)
@@ -887,7 +892,7 @@
         return
       }
 
-      const container = groups[activeGroup].sliderElements[index].querySelector(tobiContentString)
+      const container = groups[activeGroup].sliderElements[index].querySelector(tobiContentSelector)
       const type = container.getAttribute('data-type')
 
       supportedElements[type].onLeave(container)
@@ -904,7 +909,7 @@
         return
       }
 
-      const container = groups[activeGroup].sliderElements[index].querySelector(tobiContentString)
+      const container = groups[activeGroup].sliderElements[index].querySelector(tobiContentSelector)
       const type = container.getAttribute('data-type')
 
       supportedElements[type].onCleanup(container)
@@ -1034,7 +1039,7 @@
         prev()
       } else if (event.target === nextButton) {
         next()
-      } else if (event.target === closeButton || (event.target.classList.contains('slide') && config.docClose)) {
+      } else if (event.target === closeButton || (event.target.className === tobiSlideString && config.docClose)) {
         close()
       }
 
@@ -1095,7 +1100,7 @@
       drag.startX = event.touches[0].pageX
       drag.startY = event.touches[0].pageY
 
-      groups[activeGroup].slider.classList.add(sliderIsDraggingString)
+      groups[activeGroup].slider.classList.add(tobiSliderIsDraggingString)
     }
 
     /**
@@ -1124,7 +1129,7 @@
 
       pointerDown = false
 
-      groups[activeGroup].slider.classList.remove(sliderIsDraggingString)
+      groups[activeGroup].slider.classList.remove(tobiSliderIsDraggingString)
 
       if (drag.endX) {
         isDraggingX = false
@@ -1154,7 +1159,7 @@
       drag.startX = event.pageX
       drag.startY = event.pageY
 
-      groups[activeGroup].slider.classList.add(sliderIsDraggingString)
+      groups[activeGroup].slider.classList.add(tobiSliderIsDraggingString)
     }
 
     /**
@@ -1181,7 +1186,7 @@
 
       pointerDown = false
 
-      groups[activeGroup].slider.classList.remove(sliderIsDraggingString)
+      groups[activeGroup].slider.classList.remove(tobiSliderIsDraggingString)
 
       if (drag.endX) {
         isDraggingX = false
@@ -1295,8 +1300,8 @@
      *
      */
     const updateConfig = function updateConfig () {
-      if (config.draggable && groups[activeGroup].elementsLength > 1 && !groups[activeGroup].slider.classList.contains(sliderIsDraggableString)) {
-        groups[activeGroup].slider.classList.add(sliderIsDraggableString)
+      if (config.draggable && groups[activeGroup].elementsLength > 1 && !groups[activeGroup].slider.classList.contains(tobiSliderIsDraggableString)) {
+        groups[activeGroup].slider.classList.add(tobiSliderIsDraggableString)
       }
 
       // Hide buttons if necessary

--- a/js/tobi.js
+++ b/js/tobi.js
@@ -63,6 +63,17 @@
     let activeGroup = null
 
     /**
+     * Global constants
+     *
+     */
+    const tobiContentString = '.tobi .content'
+    const tobiIsOpenString = 'tobi-is-open'
+    const tobiZoomIconString = 'tobi-zoom-icon'
+    const tobiZoomString = 'tobi-zoom'
+    const sliderIsDraggingString = 'slider--is-dragging'
+    const sliderIsDraggableString = 'slider--is-draggable'
+
+    /**
      * Merge default options with user options
      *
      * @param {Object} userOptions - Optional user options
@@ -167,7 +178,7 @@
           container.appendChild(figure)
 
           // Create loading indicator
-          loadingIndicator.className = 'tobi-loader'
+          loadingIndicator.className = 'loader'
           loadingIndicator.setAttribute('role', 'progressbar')
           loadingIndicator.setAttribute('aria-label', config.loadingIndicatorLabel)
 
@@ -191,7 +202,7 @@
           }
 
           const figcaption = container.querySelector('figcaption')
-          const loadingIndicator = container.querySelector('.tobi-loader')
+          const loadingIndicator = container.querySelector('.loader')
 
           image.onload = function () {
             container.removeChild(loadingIndicator)
@@ -518,10 +529,10 @@
         if (config.zoom && el.querySelector('img')) {
           const tobiZoom = document.createElement('div')
 
-          tobiZoom.className = 'tobi-zoom__icon'
+          tobiZoom.className = tobiZoomIconString
           tobiZoom.innerHTML = config.zoomText
 
-          el.classList.add('tobi-zoom')
+          el.classList.add(tobiZoomString)
           el.appendChild(tobiZoom)
         }
 
@@ -566,10 +577,10 @@
         groups[groupName].elementsLength--
 
         // Remove zoom icon if necessary
-        if (config.zoom && el.querySelector('.tobi-zoom__icon')) {
-          const zoomIcon = el.querySelector('.tobi-zoom__icon')
+        if (config.zoom && el.querySelector('.' + tobiZoomIconString)) {
+          const zoomIcon = el.querySelector('.' + tobiZoomIconString)
 
-          zoomIcon.parentNode.classList.remove('tobi-zoom')
+          zoomIcon.parentNode.classList.remove(tobiZoomString)
           zoomIcon.parentNode.removeChild(zoomIcon)
         }
 
@@ -603,7 +614,7 @@
 
       // Create the previous button
       prevButton = document.createElement('button')
-      prevButton.className = 'tobi__prev'
+      prevButton.className = 'prev'
       prevButton.setAttribute('type', 'button')
       prevButton.setAttribute('aria-label', config.navLabel[0])
       prevButton.innerHTML = config.navText[0]
@@ -611,7 +622,7 @@
 
       // Create the next button
       nextButton = document.createElement('button')
-      nextButton.className = 'tobi__next'
+      nextButton.className = 'next'
       nextButton.setAttribute('type', 'button')
       nextButton.setAttribute('aria-label', config.navLabel[1])
       nextButton.innerHTML = config.navText[1]
@@ -619,7 +630,7 @@
 
       // Create the close button
       closeButton = document.createElement('button')
-      closeButton.className = 'tobi__close'
+      closeButton.className = 'close'
       closeButton.setAttribute('type', 'button')
       closeButton.setAttribute('aria-label', config.closeLabel)
       closeButton.innerHTML = config.closeText
@@ -627,7 +638,7 @@
 
       // Create the counter
       counter = document.createElement('div')
-      counter.className = 'tobi__counter'
+      counter.className = 'counter'
       lightbox.appendChild(counter)
 
       // Resize event using requestAnimationFrame
@@ -651,7 +662,7 @@
      */
     const createSlider = function createSlider () {
       groups[newGroup].slider = document.createElement('div')
-      groups[newGroup].slider.className = 'tobi__slider'
+      groups[newGroup].slider.className = 'slider'
       lightbox.appendChild(groups[newGroup].slider)
     }
 
@@ -668,10 +679,10 @@
             const sliderElement = document.createElement('div')
             const sliderElementContent = document.createElement('div')
 
-            sliderElement.className = 'tobi__slider__slide'
+            sliderElement.className = 'slide'
             sliderElement.style.position = 'absolute'
             sliderElement.style.left = groups[newGroup].x * 100 + '%'
-            sliderElementContent.className = 'tobi__slider__slide__content'
+            sliderElementContent.className = 'content'
 
             // Create type elements
             supportedElements[index].init(el, sliderElementContent)
@@ -719,8 +730,8 @@
       }
 
       if (config.hideScrollbar) {
-        document.documentElement.classList.add('tobi-is-open')
-        document.body.classList.add('tobi-is-open')
+        document.documentElement.classList.add(tobiIsOpenString)
+        document.body.classList.add(tobiIsOpenString)
       }
 
       updateConfig()
@@ -768,8 +779,8 @@
       }
 
       if (config.hideScrollbar) {
-        document.documentElement.classList.remove('tobi-is-open')
-        document.body.classList.remove('tobi-is-open')
+        document.documentElement.classList.remove(tobiIsOpenString)
+        document.body.classList.remove(tobiIsOpenString)
       }
 
       unbindEvents()
@@ -778,7 +789,7 @@
       lastFocus.focus()
 
       // Don't forget to cleanup our current element
-      const container = groups[activeGroup].sliderElements[groups[activeGroup].currentIndex].querySelector('.tobi__slider__slide__content')
+      const container = groups[activeGroup].sliderElements[groups[activeGroup].currentIndex].querySelector(tobiContentString)
       const type = container.getAttribute('data-type')
 
       supportedElements[type].onLeave(container)
@@ -804,7 +815,7 @@
         return
       }
 
-      const container = groups[activeGroup].sliderElements[index].querySelector('.tobi__slider__slide__content')
+      const container = groups[activeGroup].sliderElements[index].querySelector(tobiContentString)
       const type = container.getAttribute('data-type')
 
       supportedElements[type].onPreload(container)
@@ -821,7 +832,7 @@
         return
       }
 
-      const container = groups[activeGroup].sliderElements[index].querySelector('.tobi__slider__slide__content')
+      const container = groups[activeGroup].sliderElements[index].querySelector(tobiContentString)
       const type = container.getAttribute('data-type')
 
       supportedElements[type].onLoad(container)
@@ -876,7 +887,7 @@
         return
       }
 
-      const container = groups[activeGroup].sliderElements[index].querySelector('.tobi__slider__slide__content')
+      const container = groups[activeGroup].sliderElements[index].querySelector(tobiContentString)
       const type = container.getAttribute('data-type')
 
       supportedElements[type].onLeave(container)
@@ -893,7 +904,7 @@
         return
       }
 
-      const container = groups[activeGroup].sliderElements[index].querySelector('.tobi__slider__slide__content')
+      const container = groups[activeGroup].sliderElements[index].querySelector(tobiContentString)
       const type = container.getAttribute('data-type')
 
       supportedElements[type].onCleanup(container)
@@ -1023,7 +1034,7 @@
         prev()
       } else if (event.target === nextButton) {
         next()
-      } else if (event.target === closeButton || (event.target.className === 'tobi__slider__slide' && config.docClose)) {
+      } else if (event.target === closeButton || (event.target.classList.contains('slide') && config.docClose)) {
         close()
       }
 
@@ -1084,7 +1095,7 @@
       drag.startX = event.touches[0].pageX
       drag.startY = event.touches[0].pageY
 
-      groups[activeGroup].slider.classList.add('tobi__slider--is-dragging')
+      groups[activeGroup].slider.classList.add(sliderIsDraggingString)
     }
 
     /**
@@ -1113,7 +1124,7 @@
 
       pointerDown = false
 
-      groups[activeGroup].slider.classList.remove('tobi__slider--is-dragging')
+      groups[activeGroup].slider.classList.remove(sliderIsDraggingString)
 
       if (drag.endX) {
         isDraggingX = false
@@ -1143,7 +1154,7 @@
       drag.startX = event.pageX
       drag.startY = event.pageY
 
-      groups[activeGroup].slider.classList.add('tobi__slider--is-dragging')
+      groups[activeGroup].slider.classList.add(sliderIsDraggingString)
     }
 
     /**
@@ -1170,7 +1181,7 @@
 
       pointerDown = false
 
-      groups[activeGroup].slider.classList.remove('tobi__slider--is-dragging')
+      groups[activeGroup].slider.classList.remove(sliderIsDraggingString)
 
       if (drag.endX) {
         isDraggingX = false
@@ -1284,8 +1295,8 @@
      *
      */
     const updateConfig = function updateConfig () {
-      if (config.draggable && groups[activeGroup].elementsLength > 1 && !groups[activeGroup].slider.classList.contains('tobi__slider--is-draggable')) {
-        groups[activeGroup].slider.classList.add('tobi__slider--is-draggable')
+      if (config.draggable && groups[activeGroup].elementsLength > 1 && !groups[activeGroup].slider.classList.contains(sliderIsDraggableString)) {
+        groups[activeGroup].slider.classList.add(sliderIsDraggableString)
       }
 
       // Hide buttons if necessary

--- a/js/tobi.js
+++ b/js/tobi.js
@@ -518,7 +518,7 @@
         if (config.zoom && el.querySelector('img')) {
           const tobiZoom = document.createElement('div')
 
-          tobiZoom.className = 'tobi-zoom-icon'
+          tobiZoom.className = 'tobi-zoom__icon'
           tobiZoom.innerHTML = config.zoomText
 
           el.classList.add('tobi-zoom')
@@ -566,8 +566,8 @@
         groups[groupName].elementsLength--
 
         // Remove zoom icon if necessary
-        if (config.zoom && el.querySelector('.tobi-zoom-icon')) {
-          const zoomIcon = el.querySelector('.tobi-zoom-icon')
+        if (config.zoom && el.querySelector('.tobi-zoom__icon')) {
+          const zoomIcon = el.querySelector('.tobi-zoom__icon')
 
           zoomIcon.parentNode.classList.remove('tobi-zoom')
           zoomIcon.parentNode.removeChild(zoomIcon)
@@ -603,7 +603,7 @@
 
       // Create the previous button
       prevButton = document.createElement('button')
-      prevButton.className = 'prev'
+      prevButton.className = 'tobi__prev'
       prevButton.setAttribute('type', 'button')
       prevButton.setAttribute('aria-label', config.navLabel[0])
       prevButton.innerHTML = config.navText[0]
@@ -611,7 +611,7 @@
 
       // Create the next button
       nextButton = document.createElement('button')
-      nextButton.className = 'next'
+      nextButton.className = 'tobi__next'
       nextButton.setAttribute('type', 'button')
       nextButton.setAttribute('aria-label', config.navLabel[1])
       nextButton.innerHTML = config.navText[1]
@@ -619,7 +619,7 @@
 
       // Create the close button
       closeButton = document.createElement('button')
-      closeButton.className = 'close'
+      closeButton.className = 'tobi__close'
       closeButton.setAttribute('type', 'button')
       closeButton.setAttribute('aria-label', config.closeLabel)
       closeButton.innerHTML = config.closeText
@@ -627,7 +627,7 @@
 
       // Create the counter
       counter = document.createElement('div')
-      counter.className = 'tobi-counter'
+      counter.className = 'tobi__counter'
       lightbox.appendChild(counter)
 
       // Resize event using requestAnimationFrame
@@ -651,7 +651,7 @@
      */
     const createSlider = function createSlider () {
       groups[newGroup].slider = document.createElement('div')
-      groups[newGroup].slider.className = 'tobi-slider'
+      groups[newGroup].slider.className = 'tobi__slider'
       lightbox.appendChild(groups[newGroup].slider)
     }
 
@@ -668,7 +668,7 @@
             const sliderElement = document.createElement('div')
             const sliderElementContent = document.createElement('div')
 
-            sliderElement.className = 'tobi-slide'
+            sliderElement.className = 'tobi__slide'
             sliderElement.style.position = 'absolute'
             sliderElement.style.left = groups[newGroup].x * 100 + '%'
 
@@ -1022,7 +1022,7 @@
         prev()
       } else if (event.target === nextButton) {
         next()
-      } else if (event.target === closeButton || (event.target.className === 'tobi-slide' && config.docClose)) {
+      } else if (event.target === closeButton || (event.target.className === 'tobi__slide' && config.docClose)) {
         close()
       }
 
@@ -1083,7 +1083,7 @@
       drag.startX = event.touches[0].pageX
       drag.startY = event.touches[0].pageY
 
-      groups[activeGroup].slider.classList.add('tobi-slider--is-dragging')
+      groups[activeGroup].slider.classList.add('tobi__slider--is-dragging')
     }
 
     /**
@@ -1112,7 +1112,7 @@
 
       pointerDown = false
 
-      groups[activeGroup].slider.classList.remove('tobi-slider--is-dragging')
+      groups[activeGroup].slider.classList.remove('tobi__slider--is-dragging')
 
       if (drag.endX) {
         isDraggingX = false
@@ -1142,7 +1142,7 @@
       drag.startX = event.pageX
       drag.startY = event.pageY
 
-      groups[activeGroup].slider.classList.add('tobi-slider--is-dragging')
+      groups[activeGroup].slider.classList.add('tobi__slider--is-dragging')
     }
 
     /**
@@ -1169,7 +1169,7 @@
 
       pointerDown = false
 
-      groups[activeGroup].slider.classList.remove('tobi-slider--is-dragging')
+      groups[activeGroup].slider.classList.remove('tobi__slider--is-dragging')
 
       if (drag.endX) {
         isDraggingX = false
@@ -1283,8 +1283,8 @@
      *
      */
     const updateConfig = function updateConfig () {
-      if (config.draggable && groups[activeGroup].elementsLength > 1 && !groups[activeGroup].slider.classList.contains('tobi-slider--is-draggable')) {
-        groups[activeGroup].slider.classList.add('tobi-slider--is-draggable')
+      if (config.draggable && groups[activeGroup].elementsLength > 1 && !groups[activeGroup].slider.classList.contains('tobi__slider--is-draggable')) {
+        groups[activeGroup].slider.classList.add('tobi__slider--is-draggable')
       }
 
       // Hide buttons if necessary

--- a/js/tobi.js
+++ b/js/tobi.js
@@ -66,17 +66,16 @@
      * Global constants
      *
      */
-    const tobiContentString = 'tobi-content',
-      tobiIsOpenString = 'tobi-is-open',
+    const tobiIsOpenString = 'tobi-is-open',
       tobiZoomIconString = 'tobi-zoom-icon',
       tobiZoomString = 'tobi-zoom',
       tobiSliderIsDraggingString = 'tobi-slider--is-dragging',
       tobiSliderIsDraggableString = 'tobi-slider--is-draggable',
       tobiSlideString = 'tobi-slide',
       tobiLoaderString = 'tobi-loader',
-      tobiContentSelector = '.' + tobiContentString,
       tobiZoomIconSelector = '.' + tobiZoomIconString,
-      tobiLoaderSelector = '.' + tobiLoaderString
+      tobiLoaderSelector = '.' + tobiLoaderString,
+      dataTypeSelector = '[data-type]'
 
     /**
      * Merge default options with user options
@@ -687,7 +686,6 @@
             sliderElement.className = tobiSlideString
             sliderElement.style.position = 'absolute'
             sliderElement.style.left = groups[newGroup].x * 100 + '%'
-            sliderElementContent.className = tobiContentString
 
             // Create type elements
             supportedElements[index].init(el, sliderElementContent)
@@ -794,7 +792,7 @@
       lastFocus.focus()
 
       // Don't forget to cleanup our current element
-      const container = groups[activeGroup].sliderElements[groups[activeGroup].currentIndex].querySelector(tobiContentSelector)
+      const container = groups[activeGroup].sliderElements[groups[activeGroup].currentIndex].querySelector(dataTypeSelector)
       const type = container.getAttribute('data-type')
 
       supportedElements[type].onLeave(container)
@@ -820,7 +818,7 @@
         return
       }
 
-      const container = groups[activeGroup].sliderElements[index].querySelector(tobiContentSelector)
+      const container = groups[activeGroup].sliderElements[index].querySelector(dataTypeSelector)
       const type = container.getAttribute('data-type')
 
       supportedElements[type].onPreload(container)
@@ -837,7 +835,7 @@
         return
       }
 
-      const container = groups[activeGroup].sliderElements[index].querySelector(tobiContentSelector)
+      const container = groups[activeGroup].sliderElements[index].querySelector(dataTypeSelector)
       const type = container.getAttribute('data-type')
 
       supportedElements[type].onLoad(container)
@@ -892,7 +890,7 @@
         return
       }
 
-      const container = groups[activeGroup].sliderElements[index].querySelector(tobiContentSelector)
+      const container = groups[activeGroup].sliderElements[index].querySelector(dataTypeSelector)
       const type = container.getAttribute('data-type')
 
       supportedElements[type].onLeave(container)
@@ -909,7 +907,7 @@
         return
       }
 
-      const container = groups[activeGroup].sliderElements[index].querySelector(tobiContentSelector)
+      const container = groups[activeGroup].sliderElements[index].querySelector(dataTypeSelector)
       const type = container.getAttribute('data-type')
 
       supportedElements[type].onCleanup(container)

--- a/js/tobi.js
+++ b/js/tobi.js
@@ -63,21 +63,6 @@
     let activeGroup = null
 
     /**
-     * Global constants
-     *
-     */
-    const tobiIsOpenString = 'tobi-is-open',
-      tobiZoomIconString = 'tobi-zoom-icon',
-      tobiZoomString = 'tobi-zoom',
-      tobiSliderIsDraggingString = 'tobi-slider--is-dragging',
-      tobiSliderIsDraggableString = 'tobi-slider--is-draggable',
-      tobiSlideString = 'tobi-slide',
-      tobiLoaderString = 'tobi-loader',
-      tobiZoomIconSelector = '.' + tobiZoomIconString,
-      tobiLoaderSelector = '.' + tobiLoaderString,
-      dataTypeSelector = '[data-type]'
-
-    /**
      * Merge default options with user options
      *
      * @param {Object} userOptions - Optional user options
@@ -182,7 +167,7 @@
           container.appendChild(figure)
 
           // Create loading indicator
-          loadingIndicator.className = tobiLoaderString
+          loadingIndicator.className = 'tobi-loader'
           loadingIndicator.setAttribute('role', 'progressbar')
           loadingIndicator.setAttribute('aria-label', config.loadingIndicatorLabel)
 
@@ -206,7 +191,7 @@
           }
 
           const figcaption = container.querySelector('figcaption')
-          const loadingIndicator = container.querySelector(tobiLoaderSelector)
+          const loadingIndicator = container.querySelector('.tobi-loader')
 
           image.onload = function () {
             container.removeChild(loadingIndicator)
@@ -533,10 +518,10 @@
         if (config.zoom && el.querySelector('img')) {
           const tobiZoom = document.createElement('div')
 
-          tobiZoom.className = tobiZoomIconString
+          tobiZoom.className = 'tobi-zoom-icon'
           tobiZoom.innerHTML = config.zoomText
 
-          el.classList.add(tobiZoomString)
+          el.classList.add('tobi-zoom')
           el.appendChild(tobiZoom)
         }
 
@@ -581,10 +566,10 @@
         groups[groupName].elementsLength--
 
         // Remove zoom icon if necessary
-        if (config.zoom && el.querySelector(tobiZoomIconSelector)) {
-          const zoomIcon = el.querySelector(tobiZoomIconSelector)
+        if (config.zoom && el.querySelector('.tobi-zoom-icon')) {
+          const zoomIcon = el.querySelector('.tobi-zoom-icon')
 
-          zoomIcon.parentNode.classList.remove(tobiZoomString)
+          zoomIcon.parentNode.classList.remove('tobi-zoom')
           zoomIcon.parentNode.removeChild(zoomIcon)
         }
 
@@ -683,7 +668,7 @@
             const sliderElement = document.createElement('div')
             const sliderElementContent = document.createElement('div')
 
-            sliderElement.className = tobiSlideString
+            sliderElement.className = 'tobi-slide'
             sliderElement.style.position = 'absolute'
             sliderElement.style.left = groups[newGroup].x * 100 + '%'
 
@@ -733,8 +718,8 @@
       }
 
       if (config.hideScrollbar) {
-        document.documentElement.classList.add(tobiIsOpenString)
-        document.body.classList.add(tobiIsOpenString)
+        document.documentElement.classList.add('tobi-is-open')
+        document.body.classList.add('tobi-is-open')
       }
 
       updateConfig()
@@ -782,8 +767,8 @@
       }
 
       if (config.hideScrollbar) {
-        document.documentElement.classList.remove(tobiIsOpenString)
-        document.body.classList.remove(tobiIsOpenString)
+        document.documentElement.classList.remove('tobi-is-open')
+        document.body.classList.remove('tobi-is-open')
       }
 
       unbindEvents()
@@ -792,7 +777,7 @@
       lastFocus.focus()
 
       // Don't forget to cleanup our current element
-      const container = groups[activeGroup].sliderElements[groups[activeGroup].currentIndex].querySelector(dataTypeSelector)
+      const container = groups[activeGroup].sliderElements[groups[activeGroup].currentIndex].querySelector('[data-type]')
       const type = container.getAttribute('data-type')
 
       supportedElements[type].onLeave(container)
@@ -818,7 +803,7 @@
         return
       }
 
-      const container = groups[activeGroup].sliderElements[index].querySelector(dataTypeSelector)
+      const container = groups[activeGroup].sliderElements[index].querySelector('[data-type]')
       const type = container.getAttribute('data-type')
 
       supportedElements[type].onPreload(container)
@@ -835,7 +820,7 @@
         return
       }
 
-      const container = groups[activeGroup].sliderElements[index].querySelector(dataTypeSelector)
+      const container = groups[activeGroup].sliderElements[index].querySelector('[data-type]')
       const type = container.getAttribute('data-type')
 
       supportedElements[type].onLoad(container)
@@ -890,7 +875,7 @@
         return
       }
 
-      const container = groups[activeGroup].sliderElements[index].querySelector(dataTypeSelector)
+      const container = groups[activeGroup].sliderElements[index].querySelector('[data-type]')
       const type = container.getAttribute('data-type')
 
       supportedElements[type].onLeave(container)
@@ -907,7 +892,7 @@
         return
       }
 
-      const container = groups[activeGroup].sliderElements[index].querySelector(dataTypeSelector)
+      const container = groups[activeGroup].sliderElements[index].querySelector('[data-type]')
       const type = container.getAttribute('data-type')
 
       supportedElements[type].onCleanup(container)
@@ -1037,7 +1022,7 @@
         prev()
       } else if (event.target === nextButton) {
         next()
-      } else if (event.target === closeButton || (event.target.className === tobiSlideString && config.docClose)) {
+      } else if (event.target === closeButton || (event.target.className === 'tobi-slide' && config.docClose)) {
         close()
       }
 
@@ -1098,7 +1083,7 @@
       drag.startX = event.touches[0].pageX
       drag.startY = event.touches[0].pageY
 
-      groups[activeGroup].slider.classList.add(tobiSliderIsDraggingString)
+      groups[activeGroup].slider.classList.add('tobi-slider--is-dragging')
     }
 
     /**
@@ -1127,7 +1112,7 @@
 
       pointerDown = false
 
-      groups[activeGroup].slider.classList.remove(tobiSliderIsDraggingString)
+      groups[activeGroup].slider.classList.remove('tobi-slider--is-dragging')
 
       if (drag.endX) {
         isDraggingX = false
@@ -1157,7 +1142,7 @@
       drag.startX = event.pageX
       drag.startY = event.pageY
 
-      groups[activeGroup].slider.classList.add(tobiSliderIsDraggingString)
+      groups[activeGroup].slider.classList.add('tobi-slider--is-dragging')
     }
 
     /**
@@ -1184,7 +1169,7 @@
 
       pointerDown = false
 
-      groups[activeGroup].slider.classList.remove(tobiSliderIsDraggingString)
+      groups[activeGroup].slider.classList.remove('tobi-slider--is-dragging')
 
       if (drag.endX) {
         isDraggingX = false
@@ -1298,8 +1283,8 @@
      *
      */
     const updateConfig = function updateConfig () {
-      if (config.draggable && groups[activeGroup].elementsLength > 1 && !groups[activeGroup].slider.classList.contains(tobiSliderIsDraggableString)) {
-        groups[activeGroup].slider.classList.add(tobiSliderIsDraggableString)
+      if (config.draggable && groups[activeGroup].elementsLength > 1 && !groups[activeGroup].slider.classList.contains('tobi-slider--is-draggable')) {
+        groups[activeGroup].slider.classList.add('tobi-slider--is-draggable')
       }
 
       // Hide buttons if necessary

--- a/scss/tobi.scss
+++ b/scss/tobi.scss
@@ -2,54 +2,6 @@
   '_variables.scss',
   '_functions.scss';
 
-/* Link */
-.tobi-zoom {
-  border: 0;
-  box-shadow: none;
-  display: block;
-  position: relative;
-  text-decoration: none;
-
-
-  & img {
-    display: block;
-  }
-
-  &__icon {
-    align-items: center;
-    background-color: $zoom-icon-background;
-    bottom: 0;
-    color: $zoom-icon-color;
-    display: flex;
-    justify-content: center;
-    line-height: 1;
-    position: absolute;
-    right: 0;
-
-
-    & svg {
-      color: $zoom-icon-color;
-      fill: none;
-      height: em(20);
-      padding-bottom: em(4);
-      padding-left: em(4);
-      padding-right: em(4);
-      padding-top: em(4);
-      pointer-events: none;
-      stroke-linecap: square;
-      stroke-linejoin: miter;
-      stroke-width: 2;
-      stroke: $zoom-icon-color;
-      width: em(20);
-    }
-  }
-}
-
-/* Hide scrollbar if lightbox is displayed */
-.tobi-is-open {
-  overflow-y: hidden;
-}
-
 /* Lightbox */
 .tobi {
   background-color: $lightbox-background;
@@ -65,7 +17,6 @@
   top: 0;
   z-index: 1337;
 
-
   &[aria-hidden="true"] {
     display: none;
   }
@@ -75,261 +26,271 @@
   & *::after {
     box-sizing: inherit;
   }
-}
 
-/* Slider */
-.tobi__slider {
-  bottom: 0;
-  left: 0;
-  position: absolute;
-  right: 0;
-  top: 0;
-  will-change: transform;
-
-
-  &:not(&--is-dragging) {
-    transition-duration: $transition-duration;
-    transition-property: transform;
-    transition-timing-function: $transition-timing-function;
-
-    @media screen and (prefers-reduced-motion: reduce) {
-      transition: none;
-    }
+  /* Hide scrollbar if lightbox is displayed */
+  &-is-open {
+    overflow-y: hidden;
   }
 
-  &--is-draggable &__slide__content {
-    cursor: grab;
-  }
-
-  &--is-dragging &__slide__content {
-    cursor: grabbing;
-  }
-}
-
-/* Slide */
-.tobi__slider__slide {
-  align-items: center;
-  display: flex;
-  height: 100%;
-  justify-content: center;
-  width: 100%;
-}
-
-/* Slide content */
-.tobi__slider__slide__content {
-
-
-
-  > figure {
-    margin: 0;
-    position: relative;
-
-
-    > img {
-      display: block;
-      height: auto;
-      max-height: $slide-max-height;
-      max-width: $slide-max-width;
-      width: auto;
-    }
-
-    > figcaption {
-      background-color: $caption-background;
-      bottom: 0;
-      color: $caption-color;
-      display: block;
-      left: 0;
-      padding-bottom: em(4);
-      padding-left: em(8);
-      padding-right: em(8);
-      padding-top: em(4);
-      position: absolute;
-      white-space: pre-wrap;
-      width: 100%;
-    }
-  }
-
-  &[data-type="html"] {
-    max-height: $slide-max-height;
-    max-width: $slide-max-width;
-    overflow: hidden;
-    overflow-y: auto;
-    overscroll-behavior: contain;
-
-
-    & video {
-      cursor: auto;
-      display: block !important;
-      max-height: $slide-max-height;
-      max-width: $slide-max-width;
-    }
-  }
-
-  &[data-type="iframe"] {
-    max-height: $slide-max-height;
-    max-width: $slide-max-width;
-    overflow: hidden;
-    overflow-y: auto;
-    overscroll-behavior: contain;
-
-    /* Fix iframe scrolling on iOS */
-    -webkit-overflow-scrolling: touch;
-    transform: translate3d(0, 0, 0);
-
-
-    & iframe {
-      display: block !important;
-      height: $slide-max-height;
-      width: $slide-max-width;
-    }
-  }
-
-  &[data-type="youtube"] {
-    max-height: $slide-max-height;
-    max-width: $slide-max-width;
-    overflow: hidden;
-    overflow-y: auto;
-    overscroll-behavior: contain;
-
-
-    & iframe {
-      display: block !important;
-    }
-  }
-}
-
-/* Buttons */
-.tobi > button {
-  align-items: center;
-  appearance: none;
-  background-color: $button-background;
-  border: em(1) solid transparent;
-  color: $button-color;
-  cursor: pointer;
-  display: flex;
-  font: inherit;
-  justify-content: center;
-  line-height: 1;
-  margin: 0;
-  opacity: 0.5;
-  padding-bottom: em(4);
-  padding-left: em(4);
-  padding-right: em(4);
-  padding-top: em(4);
-  position: absolute;
-  touch-action: manipulation;
-  transition-duration: $transition-duration;
-  transition-property: opacity, transform;
-  transition-timing-function: $transition-timing-function;
-  will-change: opacity, transform;
-  z-index: 1;
-
-  @media screen and (prefers-reduced-motion: reduce) {
-    transition: none;
-    will-change: opacity;
-  }
-
-
-  & svg {
-    pointer-events: none;
-    stroke: #fff;
-    stroke-width: 1;
-    stroke-linecap: square;
-    stroke-linejoin: miter;
-    fill: none;
-    color: #fff;
-  }
-
-  &:active,
-  &:focus,
-  &:hover {
-    opacity: 1;
-    transform: scale(.84);
-
-    @media screen and (prefers-reduced-motion: reduce) {
-      transform: none;
-    }
-  }
-
-  &.tobi__prev,
-  &.tobi__next {
-    top: 50%;
-    top: calc(50% - #{em(40)});
-
-
-    & svg {
-      height: em(70);
-      width: em(70);
-    }
-  }
-
-  &.tobi__prev {
-    left: 0;
-  }
-
-  &.tobi__next {
-    right: 0;
-  }
-
-  &.tobi__close {
-    right: em(5);
-    top: em(18);
-
-
-    & svg {
-      height: em(60);
-      width: em(60);
-    }
-  }
-
-  &:disabled,
-  &[aria-hidden="true"] {
-    display: none;
-  }
-}
-
-/* Counter */
-.tobi__counter {
-  align-items: center;
-  background-color: $counter-background;
-  color: $counter-color;
-  display: flex;
-  font-size: em(20);
-  justify-content: center;
-  left: em(18);
-  line-height: 1;
-  position: absolute;
-  top: em(40);
-  z-index: 1;
-
-
-  &[aria-hidden="true"] {
-    display: none;
-  }
-}
-
-/* Loader */
-.tobi-loader {
-  display: inline-block;
-  height: em(100);
-  left: calc(50% - #{em(50)});
-  position: absolute;
-  top: calc(50% - #{em(50)});
-  width: em(100);
-
-
-  &::before {
-    animation: spin 1s infinite;
-    border-radius: 100%;
-    border: em(4) solid #949ba3;
-    border-top-color: $loader-color;
+  /* Slider */
+  .slider {
     bottom: 0;
-    content: "";
     left: 0;
     position: absolute;
     right: 0;
     top: 0;
+    will-change: transform;
+
+    &:not(&--is-dragging) {
+      transition-duration: $transition-duration;
+      transition-property: transform;
+      transition-timing-function: $transition-timing-function;
+
+      @media screen and (prefers-reduced-motion: reduce) {
+        transition: none;
+      }
+    }
+
+    &--is-draggable .content {
+      cursor: grab;
+    }
+
+    &--is-dragging .content {
+      cursor: grabbing;
+    }
+  }
+
+  /* Slide */
+  .slide {
+    align-items: center;
+    display: flex;
+    height: 100%;
+    justify-content: center;
+    width: 100%;
+  }
+
+  /* Slide content */
+  .content {
+    > figure {
+      margin: 0;
+      position: relative;
+
+      > img {
+        display: block;
+        height: auto;
+        max-height: $slide-max-height;
+        max-width: $slide-max-width;
+        width: auto;
+      }
+
+      > figcaption {
+        background-color: $caption-background;
+        bottom: 0;
+        color: $caption-color;
+        display: block;
+        left: 0;
+        padding-top: em(4) em(8);
+        position: absolute;
+        white-space: pre-wrap;
+        width: 100%;
+      }
+    }
+
+    &[data-type] {
+      max-height: $slide-max-height;
+      max-width: $slide-max-width;
+      overflow: hidden;
+      overflow-y: auto;
+      overscroll-behavior: contain;
+
+      iframe,
+      video {
+        display: block !important;
+      }
+    }
+
+    &[data-type="html"] {
+      video {
+        cursor: auto;
+        max-height: $slide-max-height;
+        max-width: $slide-max-width;
+      }
+    }
+
+    &[data-type="iframe"] {
+      /* Fix iframe scrolling on iOS */
+      -webkit-overflow-scrolling: touch;
+      transform: translate3d(0, 0, 0);
+
+      iframe {
+        height: $slide-max-height;
+        width: $slide-max-width;
+      }
+    }
+  }
+
+  /* Buttons */
+  > button {
+    align-items: center;
+    appearance: none;
+    background-color: $button-background;
+    border: em(1) solid transparent;
+    color: $button-color;
+    cursor: pointer;
+    display: flex;
+    font: inherit;
+    justify-content: center;
+    line-height: 1;
+    margin: 0;
+    opacity: 0.5;
+    padding: em(4);
+    position: absolute;
+    touch-action: manipulation;
+    transition-duration: $transition-duration;
+    transition-property: opacity, transform;
+    transition-timing-function: $transition-timing-function;
+    will-change: opacity, transform;
     z-index: 1;
+
+    @media screen and (prefers-reduced-motion: reduce) {
+      transition: none;
+      will-change: opacity;
+    }
+
+    svg {
+      pointer-events: none;
+      stroke: #fff;
+      stroke-width: 1;
+      stroke-linecap: square;
+      stroke-linejoin: miter;
+      fill: none;
+      color: #fff;
+    }
+
+    &:active,
+    &:focus,
+    &:hover {
+      opacity: 1;
+      transform: scale(.84);
+
+      @media screen and (prefers-reduced-motion: reduce) {
+        transform: none;
+      }
+    }
+
+    &.prev,
+    &.next {
+      top: calc(50% - #{em(35)});
+
+      svg {
+        height: em(70);
+        width: em(70);
+      }
+    }
+
+    &.prev {
+      left: 0;
+    }
+
+    &.next {
+      right: 0;
+    }
+
+    &.close {
+      right: em(5);
+      top: em(18);
+
+      svg {
+        height: em(60);
+        width: em(60);
+      }
+    }
+
+    &:disabled,
+    &[aria-hidden="true"] {
+      display: none;
+    }
+  }
+
+  /* Counter */
+  .counter {
+    align-items: center;
+    background-color: $counter-background;
+    color: $counter-color;
+    display: flex;
+    font-size: em(20);
+    justify-content: center;
+    left: em(18);
+    line-height: 1;
+    position: absolute;
+    top: em(40);
+    z-index: 1;
+
+    &[aria-hidden="true"] {
+      display: none;
+    }
+  }
+
+  /* Loader */
+  .loader {
+    display: inline-block;
+    height: em(100);
+    left: calc(50% - #{em(50)});
+    position: absolute;
+    top: calc(50% - #{em(50)});
+    width: em(100);
+
+    &::before {
+      animation: spin 1s infinite;
+      border-radius: 100%;
+      border: em(4) solid #949ba3;
+      border-top-color: $loader-color;
+      bottom: 0;
+      content: "";
+      left: 0;
+      position: absolute;
+      right: 0;
+      top: 0;
+      z-index: 1;
+    }
+  }
+
+  /* Zoom */
+  &-zoom {
+    border: 0;
+    box-shadow: none;
+    display: block;
+    position: relative;
+    text-decoration: none;
+
+    img {
+      display: block;
+    }
+
+    &-icon {
+      align-items: center;
+      background-color: $zoom-icon-background;
+      bottom: 0;
+      color: $zoom-icon-color;
+      display: flex;
+      justify-content: center;
+      line-height: 1;
+      position: absolute;
+      right: 0;
+
+      svg {
+        color: $zoom-icon-color;
+        fill: none;
+        height: em(20);
+        padding: em(4);
+        pointer-events: none;
+        stroke-linecap: square;
+        stroke-linejoin: miter;
+        stroke-width: 2;
+        stroke: $zoom-icon-color;
+        width: em(20);
+      }
+    }
   }
 }
 

--- a/scss/tobi.scss
+++ b/scss/tobi.scss
@@ -51,11 +51,11 @@
       }
     }
 
-    &--is-draggable .content {
+    &--is-draggable .tobi-content {
       cursor: grab;
     }
 
-    &--is-dragging .content {
+    &--is-dragging .tobi-content {
       cursor: grabbing;
     }
   }

--- a/scss/tobi.scss
+++ b/scss/tobi.scss
@@ -248,7 +248,7 @@
   &-zoom {
     border: 0;
     box-shadow: none;
-    display: block;
+    display: inline-block;
     position: relative;
     text-decoration: none;
 

--- a/scss/tobi.scss
+++ b/scss/tobi.scss
@@ -33,7 +33,7 @@
   }
 
   /* Slider */
-  &-slider {
+  &__slider {
     bottom: 0;
     left: 0;
     position: absolute;
@@ -61,7 +61,7 @@
   }
 
   /* Slide */
-  &-slide {
+  &__slide {
     align-items: center;
     display: flex;
     height: 100%;
@@ -170,8 +170,8 @@
       }
     }
 
-    &.prev,
-    &.next {
+    &.tobi__prev,
+    &.tobi__next {
       top: calc(50% - #{em(35)});
 
       svg {
@@ -180,15 +180,15 @@
       }
     }
 
-    &.prev {
+    &.tobi__prev {
       left: 0;
     }
 
-    &.next {
+    &.tobi__next {
       right: 0;
     }
 
-    &.close {
+    &.tobi__close {
       right: em(5);
       top: em(18);
 
@@ -205,7 +205,7 @@
   }
 
   /* Counter */
-  &-counter {
+  &__counter {
     background-color: $counter-background;
     color: $counter-color;
     font-size: em(20);
@@ -256,7 +256,7 @@
       display: block;
     }
 
-    &-icon {
+    &__icon {
       background-color: $zoom-icon-background;
       bottom: 0;
       color: $zoom-icon-color;

--- a/scss/tobi.scss
+++ b/scss/tobi.scss
@@ -128,7 +128,6 @@
   /* Buttons */
   > button {
     align-items: center;
-    appearance: none;
     background-color: $button-background;
     border: em(1) solid transparent;
     color: $button-color;

--- a/scss/tobi.scss
+++ b/scss/tobi.scss
@@ -98,8 +98,6 @@
         background-color: $caption-background;
         bottom: 0;
         color: $caption-color;
-        display: block;
-        left: 0;
         padding: em(4) em(8);
         position: absolute;
         white-space: pre-wrap;

--- a/scss/tobi.scss
+++ b/scss/tobi.scss
@@ -33,7 +33,7 @@
   }
 
   /* Slider */
-  .slider {
+  &-slider {
     bottom: 0;
     left: 0;
     position: absolute;
@@ -61,7 +61,7 @@
   }
 
   /* Slide */
-  .slide {
+  &-slide {
     align-items: center;
     display: flex;
     height: 100%;
@@ -70,7 +70,7 @@
   }
 
   /* Slide content */
-  .content {
+  &-content {
     > figure {
       margin: 0;
       position: relative;
@@ -213,7 +213,7 @@
   }
 
   /* Counter */
-  .counter {
+  &-counter {
     align-items: center;
     background-color: $counter-background;
     color: $counter-color;
@@ -232,7 +232,7 @@
   }
 
   /* Loader */
-  .loader {
+  &-loader {
     display: inline-block;
     height: em(100);
     left: calc(50% - #{em(50)});

--- a/scss/tobi.scss
+++ b/scss/tobi.scss
@@ -51,11 +51,11 @@
       }
     }
 
-    &--is-draggable .tobi-content {
+    &--is-draggable [data-type]  {
       cursor: grab;
     }
 
-    &--is-dragging .tobi-content {
+    &--is-dragging [data-type] {
       cursor: grabbing;
     }
   }
@@ -70,7 +70,18 @@
   }
 
   /* Slide content */
-  &-content {
+  [data-type] {
+    max-height: $slide-max-height;
+    max-width: $slide-max-width;
+    overflow: hidden;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+
+    iframe,
+    video {
+      display: block !important;
+    }
+    
     > figure {
       margin: 0;
       position: relative;
@@ -95,37 +106,24 @@
         width: 100%;
       }
     }
+  }
 
-    &[data-type] {
+  [data-type="html"] {
+    video {
+      cursor: auto;
       max-height: $slide-max-height;
       max-width: $slide-max-width;
-      overflow: hidden;
-      overflow-y: auto;
-      overscroll-behavior: contain;
-
-      iframe,
-      video {
-        display: block !important;
-      }
     }
+  }
 
-    &[data-type="html"] {
-      video {
-        cursor: auto;
-        max-height: $slide-max-height;
-        max-width: $slide-max-width;
-      }
-    }
+  [data-type="iframe"] {
+    /* Fix iframe scrolling on iOS */
+    -webkit-overflow-scrolling: touch;
+    transform: translate3d(0, 0, 0);
 
-    &[data-type="iframe"] {
-      /* Fix iframe scrolling on iOS */
-      -webkit-overflow-scrolling: touch;
-      transform: translate3d(0, 0, 0);
-
-      iframe {
-        height: $slide-max-height;
-        width: $slide-max-width;
-      }
+    iframe {
+      height: $slide-max-height;
+      width: $slide-max-width;
     }
   }
 

--- a/scss/tobi.scss
+++ b/scss/tobi.scss
@@ -51,7 +51,7 @@
       }
     }
 
-    &--is-draggable [data-type]  {
+    &--is-draggable [data-type] {
       cursor: grab;
     }
 

--- a/scss/tobi.scss
+++ b/scss/tobi.scss
@@ -100,7 +100,7 @@
         color: $caption-color;
         display: block;
         left: 0;
-        padding-top: em(4) em(8);
+        padding: em(4) em(8);
         position: absolute;
         white-space: pre-wrap;
         width: 100%;

--- a/scss/tobi.scss
+++ b/scss/tobi.scss
@@ -127,14 +127,11 @@
 
   /* Buttons */
   > button {
-    align-items: center;
     background-color: $button-background;
     border: em(1) solid transparent;
     color: $button-color;
     cursor: pointer;
-    display: flex;
     font: inherit;
-    justify-content: center;
     line-height: 1;
     margin: 0;
     opacity: 0.5;
@@ -209,12 +206,9 @@
 
   /* Counter */
   &-counter {
-    align-items: center;
     background-color: $counter-background;
     color: $counter-color;
-    display: flex;
     font-size: em(20);
-    justify-content: center;
     left: em(18);
     line-height: 1;
     position: absolute;
@@ -263,12 +257,9 @@
     }
 
     &-icon {
-      align-items: center;
       background-color: $zoom-icon-background;
       bottom: 0;
       color: $zoom-icon-color;
-      display: flex;
-      justify-content: center;
       line-height: 1;
       position: absolute;
       right: 0;


### PR DESCRIPTION
Hi again,

I've managed to shove off ~640 bytes of minified CSS and ~560 bytes of uglyfied JS.

This was done in:

**SCSS**
* we just can use `.tobi` namespace for all child classes. okay selectors get more complex this way but this should be no serious issue for CSS performance
* padding-top, padding-bottom, padding-left, padding-right to just `padding` in 2 cases
* refactor `&[data-type]` (`&[data-type="youtube"]` needs no special CSS any more)
* fixed `&.prev,&.next` button CSS top value (was 50% and another calced top value)

**JS**
* respect new SCSS changes
* refactor multiple occurances to new introduced `Global constants` (this can be taken further, e.g. for `'aria-hidden'` string

I've tested the new package live @ production site https://feuerwehr-eisolzried.de/ (no iframes, no youtube)

Have a nice week
midzer

edit:
there is still a bug for videos :[ hang on
edit2:
fixed, issue was on my side